### PR TITLE
Update broken links in release notes

### DIFF
--- a/release-notes/0.30.0.rst
+++ b/release-notes/0.30.0.rst
@@ -15,7 +15,7 @@ Deprecation Notes
 
     * To continue using Qiskit Runtime with IBM Cloud: migrate to Q-CTRL Fire Opal, 
       the same performance management product accessible directly through Q-CTRL. 
-      You can `connect your IBM Cloud API key and Qiskit Runtime CRN <https://docs.q-ctrl.com/fire-opal/discover/hardware-providers/how-to-authenticate-with-ibm-credentials>`__
+      You can `connect your IBM Cloud API key and Qiskit Runtime CRN <https://docs.q-ctrl.com/fire-opal/discover/hardware-providers/how-to-migrate-from-performance-management-on-ibm-cloud>`__
       to Fire Opal. (`1931 <https://github.com/Qiskit/qiskit-ibm-runtime/pull/1931>`__)
 
 - In a future release, ``RuntimeJob.status()`` will be returned as a string instead of 

--- a/release-notes/0.32.0.rst
+++ b/release-notes/0.32.0.rst
@@ -44,5 +44,5 @@ Upgrade Notes
 
       * To continue using Qiskit Runtime with IBM Cloud: migrate to Q-CTRL Fire Opal, 
         the same performance management product accessible directly through Q-CTRL. 
-        You can `connect your IBM Cloud API key and Qiskit Runtime CRN <https://docs.q-ctrl.com/fire-opal/discover/hardware-providers/how-to-authenticate-with-ibm-credentials>`__
+        You can `connect your IBM Cloud API key and Qiskit Runtime CRN <https://docs.q-ctrl.com/fire-opal/discover/hardware-providers/how-to-migrate-from-performance-management-on-ibm-cloud>`__
         to Fire Opal. (`1966 <https://github.com/Qiskit/qiskit-ibm-runtime/pull/1966>`__)


### PR DESCRIPTION
Evidently, we can't ignore broken links in release notes files, so they need to be updated to something that works.

Note for the maintainers:

We are bringing the change into Qiskit/documentation via https://github.com/Qiskit/documentation/pull/4506. In my opinion we can just update the docs on our end without needing a new patch release. Same case as https://github.com/Qiskit/qiskit-ibm-runtime/pull/2569

This change is also being made in Main